### PR TITLE
Fix contributing guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ La documentation de Visual Basic et Visual C# se trouve dans un dépôt distinc
 
 ## <a name="contributing-to-the-documentation"></a>Contribution à la documentation
 
-Pour contribuer à cette documentation, consultez le [guide du contributeur](CONTRIBUTING.md).
+Pour contribuer à cette documentation, consultez le [guide du contributeur](https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/CONTRIBUTING.md).
 Vos contributions sont les bienvenues pour nous aider à améliorer la documentation de Visual Studio. Tous les articles dans ce dépôt font appel à Markdown dans GitHub.
 
-Plusieurs fonctionnalités de Visual Studio ont leurs propres dossiers dans ce dépôt, comme **debugger** pour les rubriques sur le débogage, **ide** pour les rubriques sur l’environnement de développement intégré (IDE) de Visual Studio, et ainsi de suite. Le sous-dossier **/media** dans chaque dossier contient les fichiers art pour les rubriques. Le [guide du contributeur](CONTRIBUTING.md) contient d’autres informations.
+Plusieurs fonctionnalités de Visual Studio ont leurs propres dossiers dans ce dépôt, comme **debugger** pour les rubriques sur le débogage, **ide** pour les rubriques sur l’environnement de développement intégré (IDE) de Visual Studio, et ainsi de suite. Le sous-dossier **/media** dans chaque dossier contient les fichiers art pour les rubriques. Le [guide du contributeur](https://github.com/MicrosoftDocs/visualstudio-docs/blob/master/CONTRIBUTING.md) contient d’autres informations.
 
 Ce projet a adopté le [Code de conduite open source de Microsoft](https://opensource.microsoft.com/codeofconduct/). Pour plus d’informations, consultez la [FAQ sur le code de conduite](https://opensource.microsoft.com/codeofconduct/faq/) ou envoyez vos questions ou commentaires à [opencode@microsoft.com](mailto:opencode@microsoft.com).
 


### PR DESCRIPTION
The links to the contributing guide were broken since this repository doesn't have a CONTRIBUTING.md file.
The links now point to the english file the same way the code of conduct and his FAQ do.