### PR TITLE
Fix various typos

### DIFF
--- a/docs/debugger/how-to-specify-debugger-settings.md
+++ b/docs/debugger/how-to-specify-debugger-settings.md
@@ -29,22 +29,22 @@ ms.lasthandoff: 09/10/2018
 ms.locfileid: "44279200"
 ---
 # <a name="how-to-specify-debugger-settings"></a>Comment : spécifier les paramètres du débogueur
-Dans [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)], vous pouvez utiliser divers paramètres pour spécifier le comportement du débogueur, notamment le mode d'affichage des variables, la présentation ou non des avertissements, la définition des points d'arrêt, ainsi que la manière dont les programmes sont affectés par les interruptions. Vous spécifiez les paramètres du débogueur dans le **Options** boîte de dialogue.  
-  
-### <a name="to-set-debugger-options"></a>Pour définir les options du débogueur  
-  
-1.  Dans le menu **Outils** , cliquez sur **Options**.  
-  
-2.  Dans le **Options** boîte de dialogue, ouvrez le **débogage** dossier.  
-  
-3.  Dans le **débogage** dossier, choisissez la catégorie d’options souhaitée.  
-  
-     Options les plus courantes se trouvent dans le **général** catégorie. Pour plus d’informations, consultez [général, débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md).  
-  
-4.  Activez ou désactivez les options souhaitées. Appuyez sur F1 pour obtenir de l'aide concernant les options.  
-  
-## <a name="see-also"></a>Voir aussi  
- [Général, Débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md)   
- [Modifier & Continuer, Débogage, Boîte de dialogue Options](https://msdn.microsoft.com/library/bcew296c.aspx)   
- [Paramètres et préparation du débogueur](../debugger/debugger-settings-and-preparation.md)   
+Dans [!INCLUDE[vsprvs](../code-quality/includes/vsprvs_md.md)], vous pouvez utiliser divers paramètres pour spécifier le comportement du débogueur, notamment le mode d'affichage des variables, la présence ou non des avertissements, la définition des points d'arrêt, ainsi que la manière dont les programmes sont affectés par les interruptions. Vous spécifiez les paramètres du débogueur dans la boîte de dialogue **Options**.
+
+### <a name="to-set-debugger-options"></a>Pour définir les options du débogueur
+
+1.  Dans le menu **Outils** , cliquez sur **Options**.
+
+2.  Dans la boîte de dialogue **Options**, ouvrez le dossier **Débogage**.
+
+3.  Dans le dossier **Débogage**, choisissez la catégorie d’options souhaitée.
+
+     Les options les plus courantes se trouvent dans la catégorie **général**. Pour plus d’informations, consultez [Général, Débogage, Boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md).
+
+4.  Activez ou désactivez les options souhaitées. Appuyez sur F1 pour obtenir de l'aide concernant les options.
+
+## <a name="see-also"></a>Voir aussi
+ [Général, Débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md)
+ [Modifier & Continuer, Débogage, Boîte de dialogue Options](https://msdn.microsoft.com/library/bcew296c.aspx)
+ [Paramètres et préparation du débogueur](../debugger/debugger-settings-and-preparation.md)
  [Macros courantes pour les propriétés et les commandes de génération](/cpp/ide/common-macros-for-build-commands-and-properties)

--- a/docs/vs-2015/debugger/how-to-specify-debugger-settings.md
+++ b/docs/vs-2015/debugger/how-to-specify-debugger-settings.md
@@ -38,26 +38,26 @@ ms.locfileid: "47508289"
 # <a name="how-to-specify-debugger-settings"></a>Comment : spécifier les paramètres du débogueur
 [!INCLUDE[vs2017banner](../includes/vs2017banner.md)]
 
-Vous trouverez la dernière version de cette rubrique dans [Comment : spécifier les paramètres de débogueur](https://docs.microsoft.com/visualstudio/debugger/how-to-specify-debugger-settings).  
-  
-Dans [!INCLUDE[vsprvs](../includes/vsprvs-md.md)], vous pouvez utiliser divers paramètres pour spécifier le comportement du débogueur, notamment le mode d'affichage des variables, la présentation ou non des avertissements, la définition des points d'arrêt, ainsi que la manière dont les programmes sont affectés par les interruptions. Vous spécifiez les paramètres du débogueur dans le **Options** boîte de dialogue.  
-  
-### <a name="to-set-debugger-options"></a>Pour définir les options du débogueur  
-  
-1.  Dans le menu **Outils** , cliquez sur **Options**.  
-  
-2.  Dans le **Options** boîte de dialogue, ouvrez le **débogage** dossier.  
-  
-3.  Dans le **débogage** dossier, choisissez la catégorie d’options souhaitée.  
-  
-     Options les plus courantes se trouvent dans le **général** catégorie. Pour plus d’informations, consultez [général, débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md).  
-  
-4.  Activez ou désactivez les options souhaitées. Appuyez sur F1 pour obtenir de l'aide concernant les options.  
-  
-## <a name="see-also"></a>Voir aussi  
- [Général, Débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md)   
- [Modifier & Continuer, Débogage, Boîte de dialogue Options](http://msdn.microsoft.com/library/009d225f-ef65-463f-a146-e4c518f86103)   
- [Paramètres et préparation du débogueur](../debugger/debugger-settings-and-preparation.md)   
+Vous trouverez la dernière version de cette rubrique dans [Comment : spécifier les paramètres de débogueur](https://docs.microsoft.com/visualstudio/debugger/how-to-specify-debugger-settings).
+
+Dans [!INCLUDE[vsprvs](../includes/vsprvs-md.md)], vous pouvez utiliser divers paramètres pour spécifier le comportement du débogueur, notamment le mode d'affichage des variables, la présence ou non des avertissements, la définition des points d'arrêt, ainsi que la manière dont les programmes sont affectés par les interruptions. Vous spécifiez les paramètres du débogueur dans la boîte de dialogue **Options**.
+
+### <a name="to-set-debugger-options"></a>Pour définir les options du débogueur
+
+1.  Dans le menu **Outils** , cliquez sur **Options**.
+
+2.  Dans la boîte de dialogue **Options**, ouvrez le dossier **Débogage**.
+
+3.  Dans le dossier **Débogage**, choisissez la catégorie d’options souhaitée.
+
+     Les options les plus courantes se trouvent dans la catégorie **Général**. Pour plus d’informations, consultez [Général, Débogage, Boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md).
+
+4.  Activez ou désactivez les options souhaitées. Appuyez sur F1 pour obtenir de l'aide concernant les options.
+
+## <a name="see-also"></a>Voir aussi
+ [Général, Débogage, boîte de dialogue Options](../debugger/general-debugging-options-dialog-box.md)
+ [Modifier & Continuer, Débogage, Boîte de dialogue Options](http://msdn.microsoft.com/library/009d225f-ef65-463f-a146-e4c518f86103)
+ [Paramètres et préparation du débogueur](../debugger/debugger-settings-and-preparation.md)
  [Macros courantes pour les propriétés et les commandes de génération](http://msdn.microsoft.com/library/239bd708-2ea9-4687-b264-043f1febf98b)
 
 


### PR DESCRIPTION
Fix various translation errors & typos in `how-to-specify-debugger-setting` documentation files.