### PR TITLE
Remove duplicated translated words

### DIFF
--- a/docs/debugger/graphics/capturing-graphics-information.md
+++ b/docs/debugger/graphics/capturing-graphics-information.md
@@ -35,7 +35,7 @@ Capturez les informations graphiques de votre application Direct3D pour pouvoir 
 
 ### <a name="to-capture-a-frame"></a>Pour capturer un frame
 
-- Dans Visual Studio, dans la barre d’outils **graphiques** , cliquez sur le bouton **capturer le frame** bouton de ![capture graphique icône de bouton](media/debuggingdirectxgraphics.png "DebuggingDirectXGraphics").
+- Dans Visual Studio, dans la barre d’outils **graphiques** , cliquez sur le bouton **capturer le frame** ![capture graphique icône de bouton](media/debuggingdirectxgraphics.png "DebuggingDirectXGraphics").
 
 - Sur le clavier, appuyez sur la touche Impr. écran.
 

--- a/docs/debugger/graphics/graphics-api-and-memory-statistics.md
+++ b/docs/debugger/graphics/graphics-api-and-memory-statistics.md
@@ -36,7 +36,7 @@ Cet outil affiche la quantité de mémoire allouée par le pilote graphique pour
 
 ![Statistiques de la mémoire](media/gfx_diag_memory_statistics.png)
 
-La colonne **allocation GPU** affiche la quantité de mémoire utilisée par l’événement affiché dans la colonne d' **événement** .  Vous pouvez également sélectionner l’icône espion icône ![ Espion ](media/gfx_watch.png) pour afficher l' [historique des ressources](graphics-event-list.md#resource-history) de l’événement sélectionné.
+La colonne **allocation GPU** affiche la quantité de mémoire utilisée par l’événement affiché dans la colonne d' **événement** .  Vous pouvez également sélectionner l’icône espion ![ Espion ](media/gfx_watch.png) pour afficher l' [historique des ressources](graphics-event-list.md#resource-history) de l’événement sélectionné.
 
 Comme avec l’outil statistiques des API, vous pouvez cliquer avec le bouton droit dans la fenêtre pour copier toutes les données au format CSV, qui peuvent être collées dans des éléments tels qu’Excel pour une analyse plus poussée.
 


### PR DESCRIPTION
This pull request remove various translation duplicated UI elements words in `capturing-graphics-information` & `graphics-api-and-memory-statistics` documentation files.